### PR TITLE
Update governance.md

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -95,7 +95,7 @@ Suggestions to governance processes can always be raised in the interm at weekly
 
 ## Document History
 
-- 2024 Mar 20: update governance to retire "Director" titles in favour of Maintainers (replacing the "Director of Operations") and a BDFL (replacing the "Managing Director"). This brings SimPEG more in line with BDFL language used by other projects
+- 2024 Mar 20: update governance to retire "Director" titles in favour of Maintainers (replacing the "Director of Operations") and a BDFL (replacing the "Managing Director"). This brings SimPEG more in line with BDFL language used by other projects. Changes were made in https://github.com/simpeg/community/pull/18.
 - 2021 Apr 5: SimPEG governance suggested next steps [doc](https://docs.google.com/document/d/1Y8FZjDGZFC0dJveh-JNRuCXkOrtbrSFpZ55xi5VXDQ4/edit#), [video recording](https://youtu.be/EeoqqxmBGf0)
 - 2020 Dec 10: Governance sketch [doc](https://docs.google.com/document/d/1O9jiYvKClRvV0tcrQOA5PgEoTZ4e-gvAut2sgYM_-ho/edit#), [video recording](https://youtu.be/oLUHdmpbHNI)
 

--- a/governance.md
+++ b/governance.md
@@ -45,7 +45,7 @@ The current BDFL is
 
 ### Maintainers
 
-Maintainers help facilitate pull request reviews, triaging of issues, and software releases. Note that this doesn’t mean that they have to do all of the Pull Request Reviews and Releases; they can delegate or request involvement from other Project Contributors. Maintainers are included in the [Admin Team]( https://github.com/orgs/simpeg/teams/simpeg-admins) on GitHub. They have administrative rights on all repositories in the SimPEG GitHub organization. They also have admin rights on PyPi and Conda Forge. 
+Maintainers help facilitate pull request reviews, triaging of issues, and software releases. Note that this doesn’t mean that they have to do all of the Pull Request Reviews and Releases; they can delegate or request involvement from other Project Contributors. Maintainers are included in the [Admin Team](https://github.com/orgs/simpeg/teams/simpeg-admins) on GitHub. They have administrative rights on all repositories in the SimPEG GitHub organization. They also have admin rights on PyPI and Conda Forge. 
 
 Maintainers are appointed by the BDFL, in consultation with current maintainers and project Founders.
 

--- a/governance.md
+++ b/governance.md
@@ -18,37 +18,47 @@ This section describes the governance and leadership model of The Project.
 
 The Project roles are:
 - Founders
-- Managing Director
-- Director of Operations
-- Contributors
+- BDFL
+- Maintainers
+- Owners
 - Community
 
 ### Founders 
-The project founders are the people who started SimPEG. They hold no special authority in The Project, other than if a successor to the Managing Director is not able to be appointed. They are consulted on decisions concerning project leadership, governance, and vision. The project founders are:
+The project founders are the people who started SimPEG. They hold no special authority in The Project, other than if a successor to the BDFL is not able to be appointed. They are consulted on decisions concerning project leadership, governance, and vision. The project founders are:
 - Rowan Cockett ([@rowanc1](https://github.com/rowanc1))
 - Lindsey Heagy ([@lheagy](https://github.com/lheagy))
 - Seogi Kang ([@sgkang](https://github.com/sgkang))
 
-### Current Directors 
-The current project directors are:
-- Managing Director: Lindsey Heagy ([@lheagy](https://github.com/lheagy))
-- Director of Operations: Joe Capriotti ([@jcapriot](https://github.com/jcapriot))
-
-### Managing Director
+### Benevolent Dictator for Life
 
 This person is responsible for planning, organization, and direction of the organization's operations and programs. There is an expectation that this person invests efforts in community & organizational strategy as well as in working with the community to develop and act on the long-term vision of the project.
 
-This person also fulfills the role of a BDFL (Benevolent Dictator for Life) as is common in other open-source projects. As Dictator, they, have the authority to make all final decisions for The Project. As Benevolent, they, in practice, chooses to defer that authority to the consensus of the community discussion channels (see below). It is expected, and in the past has been the case, that the BDFL will only rarely assert their final authority. Because rarely used, we refer to the Managing Director’s final authority as a “special” or “overriding” vote. When it does occur, the BDFL override typically happens in situations where there is a deadlock in building concensus among the Community. The Project encourages others to fork the project if they disagree with the overall direction the Managing Director is taking. The Managing Director may delegate their authority on a particular decision or set of decisions to any other Contributor at their discretion.
+The role of a BDFL (Benevolent Dictator for Life) is common in other open-source projects. As Dictator, they, have the authority to make all final decisions for The Project. As Benevolent, they, in practice, chooses to defer that authority to the consensus of the community discussion channels (see below). It is expected, and in the past has been the case, that the BDFL will only rarely assert their final authority. Because rarely used, we refer to the BDFL’s final authority as a “special” or “overriding” vote. When it does occur, the BDFL override typically happens in situations where there is a deadlock in building concensus among the Community. The Project encourages others to fork the project if they disagree with the overall direction the BDFL is taking. The BDFL may delegate their authority on a particular decision or set of decisions to any other Contributor at their discretion.
 
-The Managing Director can appoint their successor, but it is expected that the Community (through the community discussion channels) would be consulted on this decision. If the Managing Director is unable to appoint a successor, the Founding Team will make this decision - preferably by consensus, but if needed, by a majority vote.
+The BDFL can appoint their successor, but it is expected that the Community (through the community discussion channels) would be consulted on this decision. If the BDFL is unable to appoint a successor, the Founding Team will make this decision - preferably by consensus, but if needed, by a majority vote.
 
-Note that the Managing Director can step down at any time, and acting in good faith, will also listen to serious calls to do so. 
+Note that the BDFL can step down at any time, and acting in good faith, will also listen to serious calls to do so. 
 
-### Director of Operations 
+The current BDFL is 
+- Lindsey Heagy ([@lheagy](https://github.com/lheagy))
 
-This person oversees and manages an organization's day-to-day operations to ensure the organization achieves its objectives. This person coordinates maintenance & development, for example facilitating pull request reviews and software releases. Note that this doesn’t mean that they have to do all of the Pull Request Reviews and Releases; they can delegate or request involvement from other Project Contributors. There is an expectation that this person invests in the technical and architectural strategy of the project. 
 
-The Director of Operations and the Managing Director have the authority to grant (and revoke if necessary) access and administrative access to SimPEG repositories and associated resources. 
+### Maintainers
+
+Maintainers help facilitate pull request reviews, triaging of issues, and software releases. Note that this doesn’t mean that they have to do all of the Pull Request Reviews and Releases; they can delegate or request involvement from other Project Contributors. Maintainers are included in the [Admin Team]( https://github.com/orgs/simpeg/teams/simpeg-admins) on GitHub. They have administrative rights on all repositories in the SimPEG GitHub organization. They also have admin rights on PyPi and Conda Forge. 
+
+Maintainers are appointed by the BDFL, in consultation with current maintainers and project Founders.
+
+These people are “Maintainers” in the SimPEG GitHub organization: 
+- Joseph Capriotti ([@jcapriot](https://github.com/jcapriot))
+- Santiago Soler ([@santisoler](https://github.com/santisoler))
+
+### Owners
+Owners have the permissions as outlined in the [GitHub docs](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners). To ensure continuity of ownership, as a project, we will always have a minimum of 2 owners, with one being the BDFL. 
+
+These people are the “Owners” of the SimPEG GitHub organization: 
+- Rowan Cockett ([@rowanc1](https://github.com/rowanc1))
+- Lindsey Heagy ([@lheagy](https://github.com/lheagy))
 
 ### Community Discussion Channels 
 
@@ -63,11 +73,11 @@ Multiple stakeholders from academia, industry, and non-profit sectors participat
 
 An Institutional Contributor is any individual Project Contributor who contributes to the project as part of their official duties at an Institutional. An Institutional Partner is any recognized legal entity in any country that employs at least 1 Institutional Contributor. Institutional Partners can be for-profit or non-profit entities.
 
-Institutions become eligible to become an Institutional Partner by employing individuals who actively contribute to The Project as part of their official duties. To state this another way, the only way for a Partner to influence the project is by actively contributing to the open development of The Project, in equal terms to any other member of the community of Contributors. Merely using Project Software in institutional context does not allow an entity to become an Institutional Partner. Financial gifts do not enable an entity to become an Institutional Partner. However, they can be acknowledged on The Project website. Once an institution becomes eligible for Institutional Partnership, any Contributor can nominate them; nominations are approved by the Managing Director.
+Institutions become eligible to become an Institutional Partner by employing individuals who actively contribute to The Project as part of their official duties. To state this another way, the only way for a Partner to influence the project is by actively contributing to the open development of The Project, in equal terms to any other member of the community of Contributors. Merely using Project Software in institutional context does not allow an entity to become an Institutional Partner. Financial gifts do not enable an entity to become an Institutional Partner. However, they can be acknowledged on The Project website. Once an institution becomes eligible for Institutional Partnership, any Contributor can nominate them; nominations are approved by the BDFL.
 
 If, at some point, an existing Institutional Partner stops having any contributing employees, then a one year grace period commences. If, at the end of this one-year period, they continue not to have any contributing employees, then their Institutional Partnership will lapse, and resuming it will require going through the normal process for new Partnerships.
 
-An Institutional Partner is free to pursue funding for their work on The Project through any legal means. This could involve a non-profit organization raising money from private foundations and donors or a for-profit company building proprietary products and services that leverage Project Software and Services. Funding acquired by Institutional Partners to work on The Project is called Institutional Funding. However, no funding obtained by an Institutional Partner can override the Managing Director. If a Partner has funding to do SimPEG work and the Community and Managing Director decides to not pursue that work as a project, the Partner is free to pursue it on their own. However, in this situation, that part of the Partner’s work will not be under the SimPEG umbrella and cannot use The Project trademarks in any way that suggests a formal relationship.
+An Institutional Partner is free to pursue funding for their work on The Project through any legal means. This could involve a non-profit organization raising money from private foundations and donors or a for-profit company building proprietary products and services that leverage Project Software and Services. Funding acquired by Institutional Partners to work on The Project is called Institutional Funding. However, no funding obtained by an Institutional Partner can override the BDFL. If a Partner has funding to do SimPEG work and the Community and BDFL decides to not pursue that work as a project, the Partner is free to pursue it on their own. However, in this situation, that part of the Partner’s work will not be under the SimPEG umbrella and cannot use The Project trademarks in any way that suggests a formal relationship.
 
 Institutional Partner benefits are:
 - acknowledgement on the SimPEG website and in talks
@@ -79,13 +89,13 @@ A list of current Institutional Partners is maintained at TODO.
 
 ### Changes to Governance
 
-We will hold an annual meeting dedicated to discussions of project governance in TODO:Month. At these meetings, we will review governance documents including this document and project roadmaps. Anyone is welcome to join these meetings. The authority to change the governance model is held by the Managing Director, but any changes to the governance model will be done in a consensus building process between the Managing Director, Project Contributors and the Community. 
+The authority to change the governance model is held by the BDFL, but any changes to the governance model will be done in a consensus building process between the BDFL, Maintainers and the Community. 
 
-Suggestions to governance processes can always be raised in the interm at weekly meetings, in the `~governance` channel on [Mattermost][mattermost], or directly to the project directors. 
+Suggestions to governance processes can always be raised in the interm at weekly meetings, in the `~governance` channel on [Mattermost][mattermost], or directly to the BDFL. 
 
 ## Document History
 
-The development of this document came primarily through two meetings: 
+- 2024 Mar 20: update governance to retire "Director" titles in favour of Maintainers (replacing the "Director of Operations") and a BDFL (replacing the "Managing Director"). This brings SimPEG more in line with BDFL language used by other projects
 - 2021 Apr 5: SimPEG governance suggested next steps [doc](https://docs.google.com/document/d/1Y8FZjDGZFC0dJveh-JNRuCXkOrtbrSFpZ55xi5VXDQ4/edit#), [video recording](https://youtu.be/EeoqqxmBGf0)
 - 2020 Dec 10: Governance sketch [doc](https://docs.google.com/document/d/1O9jiYvKClRvV0tcrQOA5PgEoTZ4e-gvAut2sgYM_-ho/edit#), [video recording](https://youtu.be/oLUHdmpbHNI)
 

--- a/governance.md
+++ b/governance.md
@@ -29,7 +29,7 @@ The project founders are the people who started SimPEG. They hold no special aut
 - Lindsey Heagy ([@lheagy](https://github.com/lheagy))
 - Seogi Kang ([@sgkang](https://github.com/sgkang))
 
-### Benevolent Dictator for Life
+### Benevolent Dictator for Life (BDFL)
 
 This person is responsible for planning, organization, and direction of the organization's operations and programs. There is an expectation that this person invests efforts in community & organizational strategy as well as in working with the community to develop and act on the long-term vision of the project.
 


### PR DESCRIPTION
Update the governance document to use the role of "Maintainers" and "BDFL" in place of the "Director" titles that were previously used. 

As [discussed in #14](https://github.com/simpeg/community/pull/#issuecomment-2010653544), this pr retires the title of “Director of Operations.” The role of Maintainer replaces the Director of Operations role and focuses the scope to SimPEG and the responsibilities of a Maintainer. In the upcomig pr, we will outline the responsibilities of being a Maintainer and GitHub Admin in the SimPEG organization. This is the group of people with the ability to merge PRs, and have access on conda-forge, pip, etc (We can use the PR to flesh out the Maintainer description). Currently, @jcapriot and @santisoler are Maintainers of SimPEG. They both have admin permissions in the project.

Additionally, we replace the name of "Managing Director" with BDFL to be more in line with other open-source projects. 

Thrilled to be making these updates and formally including @santisoler alongside @jcapriot as Maintainers of SimPEG 🚀 We have a good team! 